### PR TITLE
Feature/adding libraries folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /docroot/themes/contrib
 /docroot/sites/default/files
 /docroot/modules/degov
+/docroot/libraries
 
 # Ignore Composer-managed dependencies.
 vendor/


### PR DESCRIPTION
Adding the docroot/libraries folder to the .gitignore. 