### PR TITLE
Adding docroot/themes/degov folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /docroot/themes/contrib
 /docroot/sites/default/files
 /docroot/modules/degov
+/docroot/themes/degov
 
 # Ignore Composer-managed dependencies.
 vendor/


### PR DESCRIPTION
Adding the degov_base_theme to the .gitignore file.